### PR TITLE
build: fix dependabot alert and add config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "nuget"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "backend"
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "npm"
+    directory: "/UI"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "ui"
+    commit-message:
+      prefix: "build"
+
+  - package-ecosystem: "npm"
+    directory: "/Android"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "android"
+    commit-message:
+      prefix: "build"

--- a/backend/splitzy-dotnet/splitzy-dotnet.csproj
+++ b/backend/splitzy-dotnet/splitzy-dotnet.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Apis.Auth" Version="1.70.0" />
-    <PackageReference Include="MailKit" Version="4.14.1" />
+    <PackageReference Include="MailKit" Version="4.15.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.18" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">


### PR DESCRIPTION
## Summary
- add Dependabot configuration for GitHub Actions, NuGet, and both npm projects
- upgrade MailKit to 4.15.1 to resolve the transitive MimeKit advisory

## Verification
- dotnet list backend/splitzy-dotnet/splitzy-dotnet.csproj package --vulnerable --include-transitive
- dotnet build backend/splitzy-dotnet/splitzy-dotnet.csproj --configuration Release